### PR TITLE
refactor: 도메인 이벤트 지연 초기화 및 GCS 메타데이터 헤더 표준화

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,7 +244,7 @@ jobs:
             --max-unavailable=0
 
       - name: MIG Update 완료 대기
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           GCP_REGION: ${{ env.GCP_REGION }}
         run: |

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/gcs/GcsPresignedUrlGenerator.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/gcs/GcsPresignedUrlGenerator.kt
@@ -5,6 +5,7 @@ import com.albert.realmoneyrealtaste.application.image.dto.PresignedPutResponse
 import com.albert.realmoneyrealtaste.application.image.required.PresignedUrlGenerator
 import com.google.cloud.storage.BlobId
 import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.HttpMethod
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.Storage.SignUrlOption
 import org.springframework.beans.factory.annotation.Value
@@ -42,7 +43,7 @@ class GcsPresignedUrlGenerator(
             blobInfo,
             uploadExpirationMinutes,
             TimeUnit.MINUTES,
-            SignUrlOption.httpMethod(com.google.cloud.storage.HttpMethod.PUT),
+            SignUrlOption.httpMethod(HttpMethod.PUT),
             SignUrlOption.withV4Signature()
         )
 
@@ -68,7 +69,7 @@ class GcsPresignedUrlGenerator(
             blobInfo,
             getExpirationMinutes,
             TimeUnit.MINUTES,
-            SignUrlOption.httpMethod(com.google.cloud.storage.HttpMethod.GET),
+            SignUrlOption.httpMethod(HttpMethod.GET),
             SignUrlOption.withV4Signature()
         )
 

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/oci/OciObjectStorageConfig.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/oci/OciObjectStorageConfig.kt
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.s3.S3Configuration
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import java.net.URI
 
-@Profile("prod")
+@Profile("oci")
 @Configuration
 @ConfigurationProperties(prefix = "oci.objectstorage")
 class OciObjectStorageConfig {

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/oci/OciPresignedUrlGenerator.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/oci/OciPresignedUrlGenerator.kt
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 import java.time.Duration
 import java.time.Instant
 
-@Profile("prod")
+@Profile("oci")
 @Component
 class OciPresignedUrlGenerator(
     private val s3Presigner: S3Presigner,

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/webview/member/MemberAuthView.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/webview/member/MemberAuthView.kt
@@ -41,6 +41,7 @@ class MemberAuthView(
         val member = memberActivate.activate(token)
 
         model.addAttribute("nickname", member.nickname.value)
+        model.addAttribute("success", true)
         return MemberViews.ACTIVATE
     }
 

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/domain/comment/Comment.kt
@@ -134,7 +134,12 @@ class Comment protected constructor(
         protected set
 
     @Transient
-    private var domainEvents: MutableList<CommentDomainEvent> = mutableListOf()
+    private var _domainEvents: MutableList<CommentDomainEvent>? = null
+
+    private val domainEvents: MutableList<CommentDomainEvent>
+        get() = _domainEvents ?: mutableListOf<CommentDomainEvent>().also {
+            _domainEvents = it
+        }
 
     /**
      * 댓글 내용을 수정합니다.

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/domain/friend/Friendship.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/domain/friend/Friendship.kt
@@ -107,7 +107,12 @@ class Friendship protected constructor(
         protected set
 
     @Transient
-    private var domainEvents: MutableList<FriendDomainEvent> = mutableListOf()
+    private var _domainEvents: MutableList<FriendDomainEvent>? = null
+
+    private val domainEvents: MutableList<FriendDomainEvent>
+        get() = _domainEvents ?: mutableListOf<FriendDomainEvent>().also {
+            _domainEvents = it
+        }
 
     /**
      * 다시 친구 요청

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/domain/member/Member.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/domain/member/Member.kt
@@ -28,6 +28,7 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.Transient
 import java.time.LocalDateTime
 
 @Entity
@@ -64,7 +65,12 @@ class Member protected constructor(
 ) : BaseEntity(), AggregateRoot {
 
     @Transient
-    private var domainEvents: MutableList<MemberDomainEvent> = mutableListOf()
+    private var _domainEvents: MutableList<MemberDomainEvent>? = null
+
+    private val domainEvents: MutableList<MemberDomainEvent>
+        get() = _domainEvents ?: mutableListOf<MemberDomainEvent>().also {
+            _domainEvents = it
+        }
 
     @Embedded
     var email: Email = email

--- a/src/main/kotlin/com/albert/realmoneyrealtaste/domain/post/Post.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/domain/post/Post.kt
@@ -202,7 +202,12 @@ class Post protected constructor(
     fun isDeleted(): Boolean = status == PostStatus.DELETED
 
     @Transient
-    private var domainEvents: MutableList<PostDomainEvent> = mutableListOf()
+    private var _domainEvents: MutableList<PostDomainEvent>? = null
+
+    private val domainEvents: MutableList<PostDomainEvent>
+        get() = _domainEvents ?: mutableListOf<PostDomainEvent>().also {
+            _domainEvents = it
+        }
 
     /**
      * 도메인 이벤트 추가

--- a/src/main/resources/application-gcp.yml
+++ b/src/main/resources/application-gcp.yml
@@ -23,7 +23,6 @@ spring:
     properties:
       hibernate:
         format_sql: false
-        dialect: org.hibernate.dialect.PostgreSQLDialect
 
   # Flyway 설정
   flyway:

--- a/src/main/resources/templates/image/fragments/image-upload.html
+++ b/src/main/resources/templates/image/fragments/image-upload.html
@@ -252,11 +252,11 @@
                     method: 'PUT',
                     headers: {
                         'Content-Type': metadata['content-type'],
-                        'x-amz-meta-content-type': metadata['content-type'],
-                        'x-amz-meta-file-size': metadata['file-size'],
-                        'x-amz-meta-height': metadata['height'],
-                        'x-amz-meta-original-name': metadata['original-name'],
-                        'x-amz-meta-width': metadata['width']
+                        'x-Goog-meta-content-type': metadata['content-type'],
+                        'x-Goog-meta-file-size': metadata['file-size'],
+                        'x-Goog-meta-height': metadata['height'],
+                        'x-Goog-meta-original-name': metadata['original-name'],
+                        'x-Goog-meta-width': metadata['width']
                     },
                     body: file
                 });

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,5 +26,3 @@ app:
       expiration-hours: 24
     password-reset-token:
       expiration-hours: 1
-password:
-  mismatch: 새 비밀번호와 비밀번호 확인이 일치하지 않습니다.


### PR DESCRIPTION
## 주요 변경 사항

### Backend
- **도메인 이벤트 지연 초기화**: 모든 도메인 엔티티(Member, Comment, Friendship, Post)의 `domainEvents`를 지연 초기화 패턴으로 변경

### Frontend
- **GCS 메타데이터 헤더 표준화**: 이미지 업로드 시 메타데이터 헤더를 AWS S3 형식(`x-amz-meta-*`)에서 Google Cloud Storage 표준 형식(`x-Goog-meta-*`)으로 수정
- **클라우드 호환성**: Google Cloud Storage API 요구사항 준수

## 변경 내역

### 도메인 엔티티 수정
- [Member.kt](cci:7://file:///Users/Albert/Documents/study/RealMoneyRealTaste/src/main/kotlin/com/albert/realmoneyrealtaste/domain/member/Member.kt:0:0-0:0): domainEvents 지연 초기화 적용
- [Comment.kt](cci:7://file:///Users/Albert/Documents/study/RealMoneyRealTaste/src/main/kotlin/com/albert/realmoneyrealtaste/domain/comment/Comment.kt:0:0-0:0): domainEvents 지연 초기화 적용  
- [Friendship.kt](cci:7://file:///Users/Albert/Documents/study/RealMoneyRealTaste/src/main/kotlin/com/albert/realmoneyrealtaste/domain/friend/Friendship.kt:0:0-0:0): domainEvents 지연 초기화 적용
- [Post.kt](cci:7://file:///Users/Albert/Documents/study/RealMoneyRealTaste/src/main/kotlin/com/albert/realmoneyrealtaste/domain/post/Post.kt:0:0-0:0): domainEvents 지연 초기화 적용

### 프론트엔드 수정
- [image-upload.html](cci:7://file:///Users/Albert/Documents/study/RealMoneyRealTaste/src/main/resources/templates/image/fragments/image-upload.html:0:0-0:0): GCS 메타데이터 헤더 형식 수정

## 기술적 개선 사항

- **메모리 효율성**: 도메인 이벤트가 실제 사용될 때까지 초기화 지연
- **JPA 호환성**: 엔티티 생명주기와의 불일치 문제 해결
- **클라우드 표준 준수**: GCS API 표준 메타데이터 형식 사용