### PR TITLE
feat: GCS Presigned URL에 확장 헤더 지원 및 메타데이터 형식 표준화

### DIFF
--- a/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/gcs/GcsPresignedUrlGenerator.kt
+++ b/src/main/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/gcs/GcsPresignedUrlGenerator.kt
@@ -29,22 +29,23 @@ class GcsPresignedUrlGenerator(
         val blobId = BlobId.of(gcsConfig.bucketName, imageKey)
         val blobInfo = BlobInfo.newBuilder(blobId)
             .setContentType(request.contentType)
-            .setMetadata(
-                mapOf(
-                    "original-name" to request.fileName,
-                    "file-size" to request.fileSize.toString(),
-                    "width" to request.width.toString(),
-                    "height" to request.height.toString()
-                )
-            )
             .build()
+
+        val extHeaders = mapOf(
+            "x-goog-meta-content-type" to request.contentType,
+            "x-goog-meta-original-name" to request.fileName,
+            "x-goog-meta-file-size" to request.fileSize.toString(),
+            "x-goog-meta-width" to request.width.toString(),
+            "x-goog-meta-height" to request.height.toString()
+        )
 
         val url = storage.signUrl(
             blobInfo,
             uploadExpirationMinutes,
             TimeUnit.MINUTES,
             SignUrlOption.httpMethod(HttpMethod.PUT),
-            SignUrlOption.withV4Signature()
+            SignUrlOption.withV4Signature(),
+            SignUrlOption.withExtHeaders(extHeaders),
         )
 
         return PresignedPutResponse(

--- a/src/main/resources/templates/image/fragments/image-upload.html
+++ b/src/main/resources/templates/image/fragments/image-upload.html
@@ -251,7 +251,6 @@
                 const response = await fetch(uploadRequest.uploadUrl, {
                     method: 'PUT',
                     headers: {
-                        'Content-Type': metadata['content-type'],
                         'x-Goog-meta-content-type': metadata['content-type'],
                         'x-Goog-meta-file-size': metadata['file-size'],
                         'x-Goog-meta-height': metadata['height'],

--- a/src/test/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/gcs/GcsPresignedUrlGeneratorTest.kt
+++ b/src/test/kotlin/com/albert/realmoneyrealtaste/adapter/infrastructure/gcs/GcsPresignedUrlGeneratorTest.kt
@@ -60,8 +60,7 @@ class GcsPresignedUrlGeneratorTest {
                     any<BlobInfo>(),
                     eq(15L),
                     eq(java.util.concurrent.TimeUnit.MINUTES),
-                    any<SignUrlOption>(),
-                    any<SignUrlOption>()
+                    *anyVararg<SignUrlOption>()
                 )
             } returns mockUrl
 
@@ -87,16 +86,11 @@ class GcsPresignedUrlGeneratorTest {
                     match<BlobInfo> {
                         it.bucket == "test-bucket" &&
                             it.name == imageKey &&
-                            it.contentType == "image/jpeg" &&
-                            it.metadata?.get("original-name") == "test.jpg" &&
-                            it.metadata?.get("file-size") == "1024" &&
-                            it.metadata?.get("width") == "800" &&
-                            it.metadata?.get("height") == "600"
+                            it.contentType == "image/jpeg"
                     },
                     eq(15L),
                     eq(java.util.concurrent.TimeUnit.MINUTES),
-                    any<SignUrlOption>(),
-                    any<SignUrlOption>()
+                    *anyVararg<SignUrlOption>()
                 )
             }
         }
@@ -121,8 +115,7 @@ class GcsPresignedUrlGeneratorTest {
                     any<BlobInfo>(),
                     eq(15L),
                     eq(java.util.concurrent.TimeUnit.MINUTES),
-                    any<SignUrlOption>(),
-                    any<SignUrlOption>()
+                    *anyVararg<SignUrlOption>()
                 )
             } returns mockUrl
 
@@ -158,8 +151,7 @@ class GcsPresignedUrlGeneratorTest {
                     any<BlobInfo>(),
                     eq(15L),
                     eq(java.util.concurrent.TimeUnit.MINUTES),
-                    any<SignUrlOption>(),
-                    any<SignUrlOption>()
+                    *anyVararg<SignUrlOption>()
                 )
             } returns mockUrl
 
@@ -280,8 +272,7 @@ class GcsPresignedUrlGeneratorTest {
                     any<BlobInfo>(),
                     eq(30L),
                     eq(java.util.concurrent.TimeUnit.MINUTES),
-                    any<SignUrlOption>(),
-                    any<SignUrlOption>()
+                    *anyVararg<SignUrlOption>()
                 )
             } returns mockUrl
 
@@ -301,8 +292,7 @@ class GcsPresignedUrlGeneratorTest {
                     any<BlobInfo>(),
                     eq(30L),
                     eq(java.util.concurrent.TimeUnit.MINUTES),
-                    any<SignUrlOption>(),
-                    any<SignUrlOption>()
+                    *anyVararg<SignUrlOption>()
                 )
             }
         }


### PR DESCRIPTION
Backend:
- GcsPresignedUrlGenerator에 SignUrlOption.withExtHeaders() 추가
- HttpMethod import 정리 및 코드 개선
- 확장 헤더를 통한 GCS 메타데이터 전송 지원

Frontend:
- GCS 업로드 시 메타데이터 헤더를 x-amz-meta에서 x-Goog-meta로 표준화
- Google Cloud Storage API 표준 메타데이터 형식 준수

Changes:
- Presigned URL 생성 시 확장 헤더 옵션 추가
- 이미지 업로드 메타데이터 헤더 형식 통일
- GCS 스토리지 호환성 개선